### PR TITLE
NAS-108649 / 21.02 / Improve disk detection to work with all* block devices

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -139,18 +139,15 @@ get_raid_present()
 get_physical_disks_list()
 {
     local _disk
-
-    VAL=""
+    local _detected=""
 
     for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* /dev/mmc* 2>/dev/null | sed 's|/dev/||g')
     do
-        if ! echo $_disk | grep -E -q $(echo $VAL | tr ' ' '|') 2>/dev/null; then
-            VAL="${VAL} ${_disk}"
+        if ! echo $_disk | grep -E -q $(echo $_detected | tr ' ' '|') 2>/dev/null; then
+            _detected="${_detected} ${_disk}"
+            echo $_disk
 	fi
     done
-
-    VAL=`echo $VAL | tr ' ' '\n'`
-    export VAL
 }
 
 get_partition()
@@ -767,12 +764,9 @@ menu_install()
     fi
     
     if ${INTERACTIVE}; then
-	get_physical_disks_list
-	_disklist="${VAL}"
-
 	_list=""
 	_items=0
-	for _disk in ${_disklist}; do
+	for _disk in $(get_physical_disks_list); do
 	    _desc=$(get_media_description "${_disk}" | sed "s/'/'\\\''/g")
 	    _list="${_list} ${_disk} '${_desc}' off"
 	    _items=$((${_items} + 1))

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -120,22 +120,6 @@ is_swap_safe()
     esac
 }
 
-# return 0 if no raid devices, or !0 if there are some.
-get_raid_present()
-{
-	local _cnt
-	local _dummy
-
-	if [ ! -d "/dev/raid" ] ; then
-		return 0;
-	fi
-
-	_cnt=0
-	ls /dev/raid/ > /tmp/raidfiles
-	while read _dummy ; do _cnt=$(($_cnt + 1));done < /tmp/raidfiles
-	return $_cnt
-}
-
 get_physical_disks_list()
 {
     local _disk

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -139,12 +139,12 @@ get_raid_present()
 get_physical_disks_list()
 {
     local _disk
-    local _detected=""
+    local _detected="PLACEHOLDER_FOR_CONCAT"
 
     for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* /dev/mmc* 2>/dev/null | sed 's|/dev/||g')
     do
-        if ! echo $_disk | grep -E -q $(echo $_detected | tr ' ' '|') 2>/dev/null; then
-            _detected="${_detected} ${_disk}"
+        if ! echo $_disk | grep -E -q ${_detected} 2>/dev/null; then
+            _detected="${_detected}|${_disk}"
             echo $_disk
 	fi
     done

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -140,7 +140,12 @@ get_physical_disks_list()
 
 get_partition()
 {
-    ls /dev/$1$2 /dev/$1p$2 2>/dev/null | sed 's|/dev/||g'
+    local _partition=$(ls /dev/$1$2 /dev/$1p$2 2>/dev/null)
+    if [ -z $_partition ]; then
+        echo CANT_FIND_$1$2_OR_$1p$2
+    else
+        echo $_partition
+    fi
 }
 
 get_media_description()
@@ -281,8 +286,8 @@ install_loader()
 
 	    partition_disk=$(get_partition $_disk 2)
 	    echo "Stamping EFI loader on: ${_disk}"
-	    chroot ${_mnt} mkdosfs -F 32 -s 1 -n EFI /dev/${partition_disk}
-	    chroot ${_mnt} mount -t vfat /dev/${partition_disk} /boot/efi
+	    chroot ${_mnt} mkdosfs -F 32 -s 1 -n EFI ${partition_disk}
+	    chroot ${_mnt} mount -t vfat ${partition_disk} /boot/efi
 	    chroot ${_mnt} grub-install --target=x86_64-efi \
 		    --efi-directory=/boot/efi \
 		    --bootloader-id=debian --recheck --no-floppy
@@ -403,7 +408,7 @@ partition_disks()
 
     _disksparts=$(for _disk in ${_disks}; do
 	create_partitions ${_disk} >&2
-	echo /dev/$(get_partition ${_disk} 3)
+	echo $(get_partition ${_disk} 3)
     done)
 
     if [ $# -gt 1 ]; then

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -142,7 +142,7 @@ get_physical_disks_list()
 
     VAL=""
 
-    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* 2>/dev/null | sed 's|/dev/||g')
+    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* /dev/mmc* 2>/dev/null | sed 's|/dev/||g')
     do
         if ! echo $_disk | grep -E -q $(echo $VAL | tr ' ' '|'); then
             VAL="${VAL} ${_disk}"

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -141,12 +141,16 @@ get_physical_disks_list()
     local _disk
     local _detected="PLACEHOLDER_FOR_CONCAT"
 
-    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* /dev/mmc* 2>/dev/null | sed 's|/dev/||g')
+    for _disk in $(ls /sys/block/)
     do
-        if ! echo $_disk | grep -E -q ${_detected} 2>/dev/null; then
+        # no loopback, scsi/sata read-only or tape devices
+        if echo $_disk | grep -q -E "^loop|^sr|^st"; then
+            continue
+        fi
+        if ! echo $_disk | grep -E -q ${_detected}; then
             _detected="${_detected}|${_disk}"
             echo $_disk
-	fi
+        fi
     done
 }
 

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -144,7 +144,7 @@ get_physical_disks_list()
 
     for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* /dev/mmc* 2>/dev/null | sed 's|/dev/||g')
     do
-        if ! echo $_disk | grep -E -q $(echo $VAL | tr ' ' '|'); then
+        if ! echo $_disk | grep -E -q $(echo $VAL | tr ' ' '|') 2>/dev/null; then
             VAL="${VAL} ${_disk}"
 	fi
     done

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -139,17 +139,14 @@ get_raid_present()
 get_physical_disks_list()
 {
     local _disk
-    local _nvmedisk
 
     VAL=""
 
-    for _nvmedisk in $(ls /dev/nvme* | grep -oP '(?<=/dev/nvme).*.n.(?!p)' | sort -t: -u | sed 's/^/nvme/'); do
-        VAL="${VAL} ${_nvmedisk}"
-    done
-
-    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* 2>/dev/null | grep -v '[0-9]' | sed 's|/dev/||g')
+    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* 2>/dev/null | sed 's|/dev/||g')
     do
-	VAL="${VAL} ${_disk}"
+        if ! echo $_disk | grep -E -q $(echo $VAL | tr ' ' '|'); then
+            VAL="${VAL} ${_disk}"
+	fi
     done
 
     VAL=`echo $VAL | tr ' ' '\n'| grep -v '^cd'`

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -125,13 +125,15 @@ get_physical_disks_list()
     local _disk
     local _detected="PLACEHOLDER_FOR_CONCAT"
 
-    for _disk in $(ls /sys/block/)
-    do
-        # no loopback, scsi/sata read-only or tape devices
+    for _disk in $(ls /sys/block/); do
+        # Skip loopback, scsi/sata read-only or tape devices
         if echo $_disk | grep -q -E "^loop|^sr|^st"; then
             continue
         fi
-        if ! echo $_disk | grep -E -q ${_detected}; then
+        # Only grab the first matching device. This was really important when
+        # we listed /dev/sd* etc, but is still important with `ls /sys/block`
+        # to mask mmcblk0boot0, nvme0n1rpmb0 etc.
+        if ! echo $_disk | grep -q -E ${_detected}; then
             _detected="${_detected}|${_disk}"
             echo $_disk
         fi

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -149,7 +149,7 @@ get_physical_disks_list()
 	fi
     done
 
-    VAL=`echo $VAL | tr ' ' '\n'| grep -v '^cd'`
+    VAL=`echo $VAL | tr ' ' '\n'`
     export VAL
 }
 

--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -140,12 +140,7 @@ get_physical_disks_list()
 
 get_partition()
 {
-    check=$(echo "$1" | sed -n "/nvme/p")
-    if [ -n "$check" ]; then
-        echo "$1p$2"
-    else
-        echo "$1$2"
-    fi
+    ls /dev/$1$2 /dev/$1p$2 2>/dev/null | sed 's|/dev/||g'
 }
 
 get_media_description()


### PR DESCRIPTION
With https://github.com/truenas/truenas-build/pull/85, installation works on every block device except loopback devices, sata/scsi-attached read-only disks and tape drives which are explicitly masked.

I've confirmed installation is working on my emmc device which started this whole thing.

The commit history is very clear but may be a bit excessive. I'd be happy to squash some commits.

One thing I considered doing was filtering out virtual devices, which would automatically filter out zvols, loopback devices and who knows what else. I figured I may as well leave them in and let the user decide.