### PR TITLE
more thoroughly wipe partition table before install

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -927,7 +927,7 @@ menu_install()
 	# Destroy existing partition table, if there is any but tolerate
 	# failure.
 	for _disk in ${_realdisks}; do
-	    sgdisk --zap-all /dev/${_disk} || true
+	    wipefs -a /dev/${_disk} || echo Warning: unable to wipe partition table
 	done
     fi
 


### PR DESCRIPTION
If our installation target disk is formatted with zfs or btrfs, grub-install fails with:

```
grub-install: warning: Attempting to install GRUB to a disk with multiple partition labels. This in not supported yet.
grub-install: error: filesystem 'zfs' doesn't support blocklists.
```

Then a traceback into `truenas_install/__main__.py` where grub-install is invoked.

It looks like `sgdisk` doesn't do a good enough job at cleaning up the partition table. 

Replacing sgdisk with `wipefs -a` does work. Do that instead.