### PR TITLE
truenas-installer creates misaligned partitions

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -340,7 +340,7 @@ create_partitions()
 {
     local _disk="$1"
     local _sector_size=$(get_disk_logical_sector_size /dev/${_disk})
-    local _alignment_multiple=$((4096 / _sector_size))
+    local _alignment_multiple=4096
 
     # Create BIOS boot partition
     if ! sgdisk -a${_alignment_multiple} -n1:0:+1024K -t1:EF02 /dev/${_disk}; then


### PR DESCRIPTION
Fix partition alignment on install

JIRA: NAS-112963

Fix tested by creating iso image and installing new vm with created iso.
```
root@truenas[~]# cat /etc/version
22.02-MASTER-20211025-163823

root@truenas[~]# for i in 1 2 3; do 
for> parted /dev/sda align-check optimal ${i}
for> done
1 aligned
2 aligned
3 aligned

root@truenas[~]# fdisk --list
Disk /dev/sda: 20 GiB, 21474836480 bytes, 41943040 sectors
Disk model: VBOX HARDDISK
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 3B498986-ACA4-45EF-84F9-1631E911C41D

Device       Start      End  Sectors  Size Type
/dev/sda1     2048     4095     2048    1M BIOS boot
/dev/sda2     4096  1052671  1048576  512M EFI System
/dev/sda3  1052672 41943006 40890335 19.5G Solaris /usr & Apple ZFS
root@truenas[~]# 
```