### PR TITLE
Fix installer to activate legacy boot partition

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -343,7 +343,7 @@ create_partitions()
     local _alignment_multiple=4096
 
     # Create BIOS boot partition
-    if ! sgdisk -a${_alignment_multiple} -n1:0:+1024K -t1:EF02 /dev/${_disk}; then
+    if ! sgdisk -a${_alignment_multiple} -n1:0:+1024K -t1:EF02 -A1:set:2 /dev/${_disk}; then
             return 1
     fi
 


### PR DESCRIPTION
JIRA: NAS-113071

Unit tested by interrupting install process and modifying squashfs' copy of the `truenas-install` script
```
root@truenas[~]# cat /etc/version
22.02-MASTER-20211022-015840

root@truenas[~]# fdisk --list
Disk /dev/sda: 20 GiB, 21474836480 bytes, 41943040 sectors
Disk model: VBOX HARDDISK
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 4C286E41-1FDC-49C4-AB03-8D23585DBCE1

Device       Start      End  Sectors  Size Type
/dev/sda1     4096     6143     2048    1M BIOS boot
/dev/sda2     6144  1054719  1048576  512M EFI System
/dev/sda3  1054720 41943006 40888287 19.5G Solaris /usr & Apple ZFS
root@truenas[~]#

root@truenas[~]# [ -d /sys/firmware/efi ] && echo EFI || echo Legacy
Legacy
root@truenas[~]#
```