### PR TITLE
NAS-115482 / 22.12 / Don't set posixacl on the boot pool

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -491,7 +491,7 @@ partition_disks()
 		-o feature@lz4_compress=enabled \
 		-o feature@spacemap_histogram=enabled \
 		-o feature@userobj_accounting=enabled \
-		-O acltype=posixacl -O canmount=off -O compression=lz4 -O devices=off -O mountpoint=none \
+		-O acltype=off -O canmount=off -O compression=lz4 -O devices=off -O mountpoint=none \
 		-O normalization=formD -O relatime=on -O xattr=sa \
 		${BOOT_POOL} ${_mirror} ${_disksparts}
     zfs set compression=on ${BOOT_POOL}


### PR DESCRIPTION
There's no reason for ACLs to be set on our boot pool, moreover,
this avoids various STIG findings related to ACLs on system files.