### PR TITLE
NAS-124771 / 23.10.1 / Set compatility property on boot-pool

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -497,19 +497,8 @@ partition_disks()
 
     # Regardless of upgrade/fresh installation, if we are creating a new pool, it's going to be named after value of NEW_BOOT_POOL
     BOOT_POOL=${NEW_BOOT_POOL}
-    zpool create -f -o cachefile=/tmp/zpool.cache -o ashift=12 -d \
-		-o feature@async_destroy=enabled \
-		-o feature@bookmarks=enabled \
-		-o feature@embedded_data=enabled \
-		-o feature@empty_bpobj=enabled \
-		-o feature@enabled_txg=enabled \
-		-o feature@extensible_dataset=enabled \
-		-o feature@filesystem_limits=enabled \
-		-o feature@hole_birth=enabled \
-		-o feature@large_blocks=enabled \
-		-o feature@lz4_compress=enabled \
-		-o feature@spacemap_histogram=enabled \
-		-o feature@userobj_accounting=enabled \
+    zpool create -f -o cachefile=/tmp/zpool.cache -o ashift=12 \
+		-o compatibility=grub2 \
 		-O acltype=off -O canmount=off -O compression=lz4 -O devices=off -O mountpoint=none \
 		-O normalization=formD -O relatime=on -O xattr=sa \
 		${BOOT_POOL} ${_mirror} ${_disksparts}


### PR DESCRIPTION
Set compatibility property to 'grub2' on boot-pool. This inhibits feature
upgrades that could potentially break grub2 compatibility when zpool
upgrade is done on boot-pool to enable additional features.