### PR TITLE
NAS-125406 - Added sleep after create partitions

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -430,6 +430,8 @@ create_partitions()
         fi
     fi
 
+    sleep 20
+
     return 0
 }
 


### PR DESCRIPTION
Have the same problem as mentioned here
https://www.reddit.com/r/truenas/comments/1794z3n/error_installing_scale_lsblk_cant_find_sda3_or/ But when select shell and was checking /dev/sda3 everything was fine.  Its appeared just was some race condition when trying to check size after creating partitions using lsblk.

Adding sleep fixed everything for me. 
But if you know better way to handle (maybe do some retry sleep attempts check) - please fix that. 

Thank you!