### PR TITLE
NAS-128747 / 24.10 / Add avahi to installer

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Package: python3-truenas-installer
 Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
+         avahi-daemon,
          dialog,
          gdisk,
          openzfs,


### PR DESCRIPTION
This is first step to adding mDNS support for our installer. Separate commit to scale-build repository adds the base avahi configuration. Future commit will populate SRV record details.