### PR TITLE
NAS-129434 / 24.10 / bump tries=30 on install()

### DIFF
--- a/truenas_installer/install.py
+++ b/truenas_installer/install.py
@@ -26,7 +26,7 @@ async def install(disks, set_pmbr, authentication, post_install, sql, callback):
             disk_parts = list()
             part_num = 3
             for disk in disks:
-                found = (await get_partitions(disk, [part_num]))[part_num]
+                found = (await get_partitions(disk, [part_num], tries=30))[part_num]
                 if found is None:
                     raise InstallError(f"Failed to find data partition on {disk!r}")
                 else:


### PR DESCRIPTION
2 engineers internally have stated that they will randomly see TrueNAS fail to be installed because it can't find the data partition on the boot drive. Let's bump the `tries=30` in the `install()` to try and work-around this race condition.