### PR TITLE
NAS-129472 / 24.10 / add last resort for finding block partition devices

### DIFF
--- a/truenas_installer/utils.py
+++ b/truenas_installer/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import stat
 import subprocess
 
 __all__ = ["GiB", "get_partitions", "run"]
@@ -47,6 +48,20 @@ async def get_partitions(
             continue
 
         await asyncio.sleep(1)
+
+    empty_parts = {k: v for k, v in disk_partitions if v is None}
+    if empty_parts:
+        # sysfs is unpredictable AT BEST when expecting it to reliably populate
+        # symlinks for the block devices after a partition has been written
+        # to it. We're seeing our CI/CD randomly "fail" because sysfs hasn't
+        # been populated after partition creation. As a last resort, we'll just
+        # haphazardly check to see if the disk partitions block device exists
+        with os.scandir('/dev/') as dir_contents:
+            for dev in filter(lambda x: x.name.startswith(device), dir_contents):
+                for partnum in empty_parts:
+                    part_str = str(partnum)
+                    if dev.name[-len(part_str):] == part_str and stat.S_ISBLK(os.stat(dev.path).st_mode):
+                        disk_partitions[part_num] = f'/dev/{dev.name}'
 
     return disk_partitions
 

--- a/truenas_installer/utils.py
+++ b/truenas_installer/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import stat
 import subprocess
 
 __all__ = ["GiB", "get_partitions", "run"]
@@ -60,8 +59,8 @@ async def get_partitions(
             for dev in filter(lambda x: x.name.startswith(device), dir_contents):
                 for partnum in empty_parts:
                     part_str = str(partnum)
-                    if dev.name[-len(part_str):] == part_str and stat.S_ISBLK(os.stat(dev.path).st_mode):
-                        disk_partitions[part_num] = f'/dev/{dev.name}'
+                    if dev.name[-len(part_str):] == part_str:
+                        disk_partitions[partnum] = f'/dev/{dev.name}'
 
     return disk_partitions
 


### PR DESCRIPTION
We're seeing this often enough in our CI/CD that we need to try and fix it. This does just that by checking for the block device existence in `/dev` directory if we can't find the device in `sysfs`.