### PR TITLE
NAS-129473 / 24.10 / fix another strange error

### DIFF
--- a/truenas_installer/utils.py
+++ b/truenas_installer/utils.py
@@ -41,7 +41,10 @@ async def get_partitions(
                             if _part in partitions:
                                 # looks like {1: '/dev/sda1', 2: '/dev/nvme0n1p2'}
                                 disk_partitions[_part] = f'/dev/{partdir.name}'
-                        except ValueError:
+                        except (OSError, ValueError):
+                            # OSError: [Errno 19] No such device was seen on
+                            # our internal CI/CD infrastructure for reasons
+                            # not understood...
                             continue
         except FileNotFoundError:
             continue


### PR DESCRIPTION
OSError, Errno 19 is rather strange to get when opening a file that _exists_ in sysfs. Not quite sure what's going on there but instead of crashing, we'll catch it all the same like we do with `ValueError`.