### PR TITLE
try to help partition detection

### DIFF
--- a/truenas_installer/utils.py
+++ b/truenas_installer/utils.py
@@ -25,6 +25,15 @@ async def get_partitions(
     else:
         tries = min(tries, MAX_PARTITION_WAIT_TIME_SECS)
 
+    # by the time this function is called, partitions should have been
+    # written to the disk. However, it doesn't mean the kernel/udev has
+    # updated the various symlinks in sysfs. We'll open the block device
+    # in write mode. This should send a kernel and udev change event for
+    # the device and any partitions as well. Ideally, this will help bubble
+    # up the events so sysfs is populated before the logic below kicks in
+    with open(device, 'w'):
+        pass
+
     disk_partitions = {i: None for i in partitions}
     device = device.removeprefix('/dev/')
     for _try in range(tries):


### PR DESCRIPTION
We're still seeing, albeit not as often, VMs fail the install because our installer states it can't find the partitioned block devices. To try and alleviate this, I've added a simple `with open(dev, 'w'): pass` line to this function. This kicks off kernel and udev change events so, in theory, this should help bubble up the events through the kernel so the various symlinks get created in sysfs. We do this _before_ waiting on the partitions to exist to try and jump start the process.