### PR TITLE
NAS-130620 / 25.04 / improve list_disks()

### DIFF
--- a/truenas_installer/disks.py
+++ b/truenas_installer/disks.py
@@ -78,4 +78,8 @@ async def list_disks():
             )
         )
 
-    return disks
+    # we sort the disks by name because `nvme` comes before `sd*`
+    # and our appliances have nvme boot drives so by putting nvme
+    # devices up top in the installer, it provides a convenience
+    # for other departments
+    return sorted(disks, key=lambda x: x.name)

--- a/truenas_installer/disks.py
+++ b/truenas_installer/disks.py
@@ -48,7 +48,7 @@ async def list_disks():
         elif re.search(fr"{device}p?[0-9]+", mtab):
             continue
 
-        model = "Unknown Device"
+        model = "Unknown Model"
         if m := re.search("Model: (.+)", (await run(["sgdisk", "-p", device], check=False)).stdout):
             model = m.group(1)
 

--- a/truenas_installer/disks.py
+++ b/truenas_installer/disks.py
@@ -41,14 +41,11 @@ async def list_disks():
         (await run(["lsblk", "-b", "-fJ", "-o", "name,fstype,label,rm,size"])).stdout
     )["blockdevices"]:
         device = f"/dev/{disk['name']}"
-
         if disk["name"].startswith(("dm", "loop", "md", "sr", "st")):
             continue
-
-        if disk["size"] < MIN_DISK_SIZE:
+        elif disk["size"] < MIN_DISK_SIZE:
             continue
-
-        if re.search(fr"{device}p?[0-9]+", mtab):
+        elif re.search(fr"{device}p?[0-9]+", mtab):
             continue
 
         model = "Unknown Device"

--- a/truenas_installer/disks.py
+++ b/truenas_installer/disks.py
@@ -44,7 +44,7 @@ async def list_disks():
             continue
         elif disk["size"] < MIN_DISK_SIZE:
             continue
-        elif re.search(fr"/dev/{disk["model"]}p?[0-9]+", mtab):
+        elif re.search(fr"/dev/{disk["name"]}p?[0-9]+", mtab):
             continue
 
         zfs_members = []

--- a/truenas_installer/disks.py
+++ b/truenas_installer/disks.py
@@ -38,7 +38,7 @@ async def list_disks():
 
     disks = []
     for disk in json.loads(
-        (await run(["lsblk", "-b", "-fJ", "-o", "name,fstype,label,log-sec,rm,size"])).stdout
+        (await run(["lsblk", "-b", "-fJ", "-o", "name,fstype,label,rm,size"])).stdout
     )["blockdevices"]:
         device = f"/dev/{disk['name']}"
 


### PR DESCRIPTION
Quite a few improvements here:

1. remove `log-sec` option, it's not used
2. remove `sgdisk -p` subprocess for each disk (lsblk already provides this info)
3. sort the disks based on disk.name attribute so that nvme* comes before sd* drives.