### PR TITLE
NAS-136283 / 25.10 / Make IPs optional for TNC

### DIFF
--- a/truenas_installer/network_interfaces.py
+++ b/truenas_installer/network_interfaces.py
@@ -1,8 +1,13 @@
 from dataclasses import dataclass
+import ipaddress
+import logging
 
 from pyroute2 import IPRoute, NetlinkDumpInterrupted
 
-__all__ = ["list_network_interfaces"]
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["list_network_interfaces", "get_available_ip_addresses"]
 
 
 @dataclass
@@ -34,3 +39,83 @@ async def list_network_interfaces():
         interface for interface in interfaces
         if interface.name not in ["lo"]
     ]
+
+
+async def get_available_ip_addresses():
+    """
+    Get all available IP addresses on the system that can be used to connect from another machine.
+    Excludes loopback, link-local, and wildcard addresses.
+
+    Returns:
+        dict: {"ipv4": [...], "ipv6": [...]}
+    """
+    result = {"ipv4": [], "ipv6": []}
+
+    max_retries = 3
+    for attempt in range(1, max_retries + 1):
+        try:
+            with IPRoute() as ipr:
+                # Get all addresses
+                addresses = ipr.get_addr()
+
+                for addr in addresses:
+                    # Get the IP address
+                    ip_str = addr.get_attr("IFA_ADDRESS")
+                    if not ip_str:
+                        continue
+
+                    # Get the interface index and check if it's loopback
+                    if_index = addr["index"]
+                    try:
+                        link = ipr.get_links(if_index)[0]
+                        if_name = link.get_attr("IFLA_IFNAME")
+                        if if_name == "lo":
+                            continue
+                    except (IndexError, KeyError):
+                        continue
+
+                    try:
+                        ip_obj = ipaddress.ip_address(ip_str)
+
+                        # Skip loopback addresses
+                        if ip_obj.is_loopback:
+                            continue
+
+                        # Skip link-local addresses
+                        if ip_obj.is_link_local:
+                            continue
+
+                        # Skip wildcard addresses
+                        if ip_obj == ipaddress.ip_address("0.0.0.0") or ip_obj == ipaddress.ip_address("::"):
+                            continue
+
+                        # Skip multicast addresses
+                        if ip_obj.is_multicast:
+                            continue
+
+                        # Add to appropriate list
+                        if isinstance(ip_obj, ipaddress.IPv4Address):
+                            if ip_str not in result["ipv4"]:
+                                result["ipv4"].append(ip_str)
+                        elif isinstance(ip_obj, ipaddress.IPv6Address):
+                            if ip_str not in result["ipv6"]:
+                                result["ipv6"].append(ip_str)
+
+                    except ValueError:
+                        # Invalid IP address, skip
+                        continue
+
+            # Success, break out of retry loop
+            break
+
+        except NetlinkDumpInterrupted:
+            if attempt < max_retries:
+                continue
+            else:
+                logger.error("Failed to get IP addresses after %d retries due to NetlinkDumpInterrupted", max_retries)
+                return result
+        except Exception as e:
+            logger.error("Error getting IP addresses: %s", e, exc_info=True)
+            return result
+
+    return result

--- a/truenas_installer/server/api/info.py
+++ b/truenas_installer/server/api/info.py
@@ -1,11 +1,14 @@
 from dataclasses import asdict
 
 from truenas_installer.disks import list_disks as _list_disks
-from truenas_installer.network_interfaces import list_network_interfaces as _list_network_interfaces
+from truenas_installer.network_interfaces import (
+    list_network_interfaces as _list_network_interfaces,
+    get_available_ip_addresses as _get_available_ip_addresses
+)
 from truenas_installer.lock import installation_lock
 from truenas_installer.server.method import method
 
-__all__ = ["system_info", "list_disks", "list_network_interfaces"]
+__all__ = ["system_info", "list_disks", "list_network_interfaces", "get_available_ip_addresses"]
 
 
 @method(None, {
@@ -71,3 +74,24 @@ async def list_network_interfaces(context):
     Provides list of available network interfaces.
     """
     return [asdict(interface) for interface in await _list_network_interfaces()]
+
+
+@method(None, {
+    "type": "object",
+    "properties": {
+        "ipv4": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "ipv6": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+})
+async def get_available_ip_addresses(context):
+    """
+    Provides available IP addresses on the system that can be used to connect from another machine.
+    Excludes loopback, link-local, and wildcard addresses.
+    """
+    return await _get_available_ip_addresses()


### PR DESCRIPTION
This PR adds changes to auto-detect available IPs on the system and use them instead if no IPs are provided by consumer when configuring TNC.