### PR TITLE
fix exiting loop early if `/sys/block/${dev}/` has boot section

### DIFF
--- a/truenas_installer/utils.py
+++ b/truenas_installer/utils.py
@@ -44,17 +44,20 @@ async def get_partitions(
         try:
             with os.scandir(f"/sys/block/{device}") as dir_contents:
                 for partdir in filter(lambda x: x.is_dir() and x.name.startswith(device), dir_contents):
-                    with open(os.path.join(partdir.path, 'partition')) as f:
-                        try:
-                            _part = int(f.read().strip())
-                            if _part in partitions:
-                                # looks like {1: '/dev/sda1', 2: '/dev/nvme0n1p2'}
-                                disk_partitions[_part] = f'/dev/{partdir.name}'
-                        except (OSError, ValueError):
-                            # OSError: [Errno 19] No such device was seen on
-                            # our internal CI/CD infrastructure for reasons
-                            # not understood...
-                            continue
+                    try:
+                        with open(os.path.join(partdir.path, 'partition')) as f:
+                            try:
+                                _part = int(f.read().strip())
+                                if _part in partitions:
+                                    # looks like {1: '/dev/sda1', 2: '/dev/nvme0n1p2'}
+                                    disk_partitions[_part] = f'/dev/{partdir.name}'
+                            except (OSError, ValueError):
+                                # OSError: [Errno 19] No such device was seen on
+                                # our internal CI/CD infrastructure for reasons
+                                # not understood...
+                                continue
+                    except FileNotFoundError:
+                        continue
         except FileNotFoundError:
             continue
 


### PR DESCRIPTION
I was trying to install the truenas on mmcblk0.
It fails for `Failed to find partition number 2 on mmcblk0`.

I noticed that `/sys/block/mmcblk0` has `mmcblk0boot0` and `mmcblk0boot1` in there.
The script was trying to read `/sys/block/mmcblk0/mmcblk0boot0/partition` and `/sys/block/mmcblk0/mmcblk0boot1/partition` (if I remember correctly. I was playing around truenas as work and this is my free time OSS contribution) which are nonexistent. That was causing early loop exit.

I applied this fix by manually editing the script in bootable USB's overlay fs.
And it worked for me and now I think I need to let everyone know about this.