### PR TITLE
NAS-139622 / 26.0.0-BETA.1 / Reuse output from register_update_ips

### DIFF
--- a/truenas_installer/server/api/truenas_connect/acme.py
+++ b/truenas_installer/server/api/truenas_connect/acme.py
@@ -9,8 +9,8 @@ async def finalize_steps_after_registration() -> dict:
     # 1. Making sure we register/update ips with TNC so domains can point to that
     # 2. Initiate cert generation process and complete it
     tnc_config = get_tnc_config()
-    await register_update_ips(tnc_config, tnc_config['ips'] + tnc_config['interfaces_ips'], True)
-    cert_details = await create_cert(tnc_config)
+    resp = await register_update_ips(tnc_config, tnc_config['ips'] + tnc_config['interfaces_ips'], True)
+    cert_details = await create_cert(tnc_config, resp['response'] or {})
     return update_tnc_config({
         'csr_public_key': cert_details['csr'],
         'certificate_public_key': cert_details['cert'],


### PR DESCRIPTION
This commit adds changes to reflect changed function signature of create_cert where we now pass in hostname details instead of querying them separately.