### PR TITLE
NAS-140997 / 27.0.0-BETA.1 / Refuse install on DTB-based ARM boards

### DIFF
--- a/truenas_installer/installer.py
+++ b/truenas_installer/installer.py
@@ -5,5 +5,6 @@ class Installer:
     def __init__(self, version, vendor, tn_model):
         self.version = version
         self.efi = os.path.exists("/sys/firmware/efi")
+        self.dtb = os.path.exists("/sys/firmware/devicetree/base")
         self.vendor = vendor
         self.tn_model = tn_model

--- a/truenas_installer/installer_menu.py
+++ b/truenas_installer/installer_menu.py
@@ -10,6 +10,11 @@ from .serial import serial_sql
 
 _BINARY_SIZE_UNITS = ("KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
 
+_UNSUPPORTED_DTB_MESSAGE = (
+    "This system booted using a device tree (DTB). TrueNAS does not support DTB-based ARM boards; "
+    "proceeding with installation would likely result in a kernel panic."
+)
+
 
 def format_size_binary(num_bytes):
     if num_bytes == 0:
@@ -32,6 +37,8 @@ class InstallerMenu:
         self.installer = installer
 
     async def run(self):
+        if self.installer.dtb:
+            await dialog_msgbox("Unsupported Platform", _UNSUPPORTED_DTB_MESSAGE)
         await self._main_menu()
 
     async def _main_menu(self):
@@ -51,6 +58,10 @@ class InstallerMenu:
             await self._main_menu()
 
     async def _install_upgrade_internal(self):
+        if self.installer.dtb:
+            await dialog_msgbox("Unsupported Platform", _UNSUPPORTED_DTB_MESSAGE)
+            return False
+
         disks = await list_disks()
         vendor = self.installer.vendor
 

--- a/truenas_installer/server/api/info.py
+++ b/truenas_installer/server/api/info.py
@@ -19,6 +19,7 @@ __all__ = ["system_info", "list_disks", "list_network_interfaces", "get_availabl
         "installation_error": {'oneOf': [{'type': 'null'}, {'type': 'string'}]},
         "version": {"type": "string"},
         "efi": {"type": "boolean"},
+        "dtb": {"type": "boolean"},
     },
 })
 async def system_info(context):
@@ -31,6 +32,7 @@ async def system_info(context):
         "installation_error": context.server.installation_error,
         "version": context.server.installer.version,
         "efi": context.server.installer.efi,
+        "dtb": context.server.installer.dtb,
     }
 
 


### PR DESCRIPTION
## Problem
The aarch64 installer happily proceeds on DTB-based ARM boards (SBCs and similar non-ACPI/UEFI hardware), then kernel-panics partway through. We only support ACPI/UEFI ARM platforms, so the install should bail before touching anything instead of failing mid-flight.

## Solution
Detect a DTB boot via `/sys/firmware/devicetree/base` on `Installer` startup, surface a dialog at TUI launch, and short-circuit `_install_upgrade_internal` with the same message so Shell / Reboot / Shutdown stay usable but Install/Upgrade refuses. The flag is also exposed alongside `efi` on the `system_info` RPC so the builder and other non-TUI drivers can branch on it without scraping dialogs.